### PR TITLE
move CNAME file to public folder

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.devquest.fr


### PR DESCRIPTION
Déplacement du fichier `CNAME` dans le dossier public. 
Au moment du build le contenu du dossier est copier dans l'output dir de build (`docs`) ce qui évite de le voir supprimer lors d'un build en local. 

Je pense pas qu'il y ait d'impact particulier à le rajouter à ce dossier, vous en pensez quoi ? 