### PR TITLE
feat: ajoute le logo Macif dans la page sponsors

### DIFF
--- a/src/data/partenaires.json
+++ b/src/data/partenaires.json
@@ -91,6 +91,13 @@
     "actif": true
   },
   {
+    "name": "Macif",
+    "asset": "macif.webp",
+    "site": "https://www.macif.fr/",
+    "level": "COMMUN",
+    "actif": true
+  },
+  {
     "name": "Socram Banque",
     "asset": "socram.webp",
     "site": "https://www.socram-banque.fr/",


### PR DESCRIPTION
## Summary
- Ajout de la Macif dans `src/data/partenaires.json` avec le niveau COMMUN
- Le logo `macif.webp` était déjà présent dans `public/partenaires/`

## Test plan
- [ ] Vérifier que le logo Macif s'affiche correctement dans la page sponsors
- [ ] Vérifier que le niveau COMMUN est bien appliqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)